### PR TITLE
make audioset the default weights, otherwise no weights are loaded

### DIFF
--- a/vggish_keras/__init__.py
+++ b/vggish_keras/__init__.py
@@ -18,7 +18,7 @@ def get_embeddings(filename=None, y=None, sr=None, **kw):
     return Z, get_timesteps(Z, pump, sampler)
 
 def get_embedding_model(model=None, pump=None, sampler=None, hop_duration=None,
-                        include_top=None, compress=None, weights=None,):
+                        include_top=None, compress=None, weights="audioset",):
     # make sure we have model, pump, and sampler
     # get the sampler with the proper frame sizes
     pump = pump or get_pump()


### PR DESCRIPTION
``If I'm using the demo code from the readme, the models are initiated with random weights and the audioset-weights are not being loaded. Here is some demo-code showing that the model is different. This should give two identical results. But if you remove the "weights" argument, it will give two different results.

```
import librosa
import numpy as np
import vggish_keras as vgk
import tensorflow as tf

y, sr = librosa.load(librosa.util.example_audio_file())

tf.random.set_seed(1)
compute = vgk.get_embedding_function(hop_duration=0.25, weights='audioset')
Z, ts = compute(y=y, sr=sr)
print("first run", Z.flatten()[:10])

tf.random.set_seed(2)
compute = vgk.get_embedding_function(hop_duration=0.25, weights='audioset')
Z, ts = compute(y=y, sr=sr)
print("second run", Z.flatten()[:10])
```
